### PR TITLE
Refactor ExplorePage and move navigation bar to HomePage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:drkerapp/pages/explore_page.dart';
+import 'package:drkerapp/pages/read_page.dart';       // <-- add this
+import 'package:drkerapp/pages/search_page.dart';     // <-- add this
 
 void main() {
   runApp(const MyApp());
@@ -16,12 +18,51 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
-        scaffoldBackgroundColor: const Color(0xFFF7F8FD), // matches your ExplorePage card background
+        scaffoldBackgroundColor: const Color(0xFFF7F8FD),
       ),
-      home: const Scaffold(
-        body: SafeArea(
-          child: ExplorePage(),
-        ),
+      home: const HomePage(), // 👈 switch this to HomePage
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _currentIndex = 0;
+
+  final List<Widget> _screens = [
+    const ExplorePage(),
+    ReadPage(),
+    const SearchPage(),
+    const Center(child: Text('Search Page')), // Placeholder
+    const Center(child: Text('Profile Page')), // Placeholder
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(child: _screens[_currentIndex]),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        selectedItemColor: const Color(0xFF006FFD),
+        unselectedItemColor: const Color(0xFF71727A),
+        type: BottomNavigationBarType.fixed,
+        onTap: (index) {
+          setState(() {
+            _currentIndex = index;
+          });
+        },
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.explore), label: 'Explore'),
+          BottomNavigationBarItem(icon: Icon(Icons.book), label: 'Read'),
+          BottomNavigationBarItem(icon: Icon(Icons.search), label: 'Search'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+        ],
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:drkerapp/pages/explore_page.dart'; // Use the new HomePage
+import 'package:drkerapp/pages/explore_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -11,12 +11,18 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       title: 'DrKer Ministry',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
+        scaffoldBackgroundColor: const Color(0xFFF7F8FD), // matches your ExplorePage card background
       ),
-      home: const HomePage(), // <-- Set HomePage as the starting page
+      home: const Scaffold(
+        body: SafeArea(
+          child: ExplorePage(),
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/explore_page.dart
+++ b/lib/pages/explore_page.dart
@@ -1,51 +1,9 @@
+// lib/pages/explore_page.dart
+
 import 'package:flutter/material.dart';
-import 'package:drkerapp/pages/search_page.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
-import 'read_page.dart';
-
-class HomePage extends StatefulWidget {
-  const HomePage({super.key});
-
-  @override
-  State<HomePage> createState() => _HomePageState();
-}
-
-class _HomePageState extends State<HomePage> {
-  int _currentIndex = 0;
-
-  final List<Widget> _screens = [
-    const ExplorePage(),
-    ReadPage(),
-    const SearchPage(),
-    Center(child: Text('Search Page')), // Placeholder
-    Center(child: Text('Profile Page')), // Placeholder
-  ];
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(child: _screens[_currentIndex]),
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _currentIndex,
-        selectedItemColor: const Color(0xFF006FFD),
-        unselectedItemColor: const Color(0xFF71727A),
-        type: BottomNavigationBarType.fixed,
-        onTap: (index) {
-          setState(() {
-            _currentIndex = index;
-          });
-        },
-        items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.explore), label: 'Explore'),
-          BottomNavigationBarItem(icon: Icon(Icons.book), label: 'Read'),
-          BottomNavigationBarItem(icon: Icon(Icons.search), label: 'Search'),
-          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
-        ],
-      ),
-    );
-  }
-}
+import 'package:drkerapp/utility/constants.dart';
 
 class ExplorePage extends StatelessWidget {
   const ExplorePage({super.key});
@@ -112,9 +70,7 @@ class ExplorePage extends StatelessWidget {
           const SizedBox(width: 12),
           IconButton(
             icon: const Icon(Icons.menu),
-            onPressed: () {
-              print("Menu icon tapped");
-            },
+            onPressed: () => print("Menu icon tapped"),
           ),
         ],
       ),
@@ -123,7 +79,7 @@ class ExplorePage extends StatelessWidget {
 
   Widget _buildYouTubeSection() {
     return FutureBuilder<List<VideoItem>>(
-      future: YouTubeService.fetchLatestVideos('UCkcmd1DLH_6kpc9yoBqO9wg'),
+      future: YouTubeService.fetchLatestVideos(AppConstants.drKerYouTubeChannelId),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return const Padding(
@@ -137,8 +93,7 @@ class ExplorePage extends StatelessWidget {
           );
         } else {
           final cards = snapshot.data!.map((video) =>
-              _buildVideoCard(title: video.title, imageUrl: video.thumbnailUrl))
-              .toList();
+              _buildVideoCard(title: video.title, imageUrl: video.thumbnailUrl)).toList();
           return _buildHorizontalCardList(title: 'DrKerYouTube', cards: cards);
         }
       },
@@ -147,7 +102,7 @@ class ExplorePage extends StatelessWidget {
 
   Widget _buildLibrarySection() {
     return FutureBuilder<List<VideoItem>>(
-      future: YouTubeService.fetchLatestVideos('UCHwMNHKk2uzTEENHnRrs9Ew'),
+      future: YouTubeService.fetchLatestVideos(AppConstants.drKerLibraryChannelId),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return const Padding(
@@ -161,8 +116,7 @@ class ExplorePage extends StatelessWidget {
           );
         } else {
           final cards = snapshot.data!.map((video) =>
-              _buildVideoCard(title: video.title, imageUrl: video.thumbnailUrl))
-              .toList();
+              _buildVideoCard(title: video.title, imageUrl: video.thumbnailUrl)).toList();
           return _buildHorizontalCardList(title: 'DrKerLibrary', cards: cards);
         }
       },
@@ -179,35 +133,20 @@ class ExplorePage extends StatelessWidget {
             child: CircularProgressIndicator(),
           );
         } else if (snapshot.hasError) {
-          return Padding(
-            padding: const EdgeInsets.all(16),
+          return const Padding(
+            padding: EdgeInsets.all(16),
             child: Text('Error loading blog posts.'),
           );
         } else if (snapshot.data!.isEmpty) {
-          return Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 16.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: const [
-                Text(
-                  'Latest Blog Posts',
-                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
-                ),
-                SizedBox(height: 8),
-                Text(
-                  'Blog feature coming soon...',
-                  style: TextStyle(fontSize: 12, color: Colors.grey),
-                ),
-              ],
-            ),
+          return const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+            child: Text('Blog feature coming soon...'),
           );
         } else {
-          return _buildHorizontalCardList(
-            title: 'Latest Blog Posts',
-            cards: snapshot.data!
-                .map((blog) => _buildVideoCard(title: blog.title, imageUrl: blog.thumbnailUrl))
-                .toList(),
-          );
+          final cards = snapshot.data!
+              .map((blog) => _buildVideoCard(title: blog.title, imageUrl: blog.thumbnailUrl))
+              .toList();
+          return _buildHorizontalCardList(title: 'Latest Blog Posts', cards: cards);
         }
       },
     );
@@ -289,12 +228,11 @@ class ExplorePage extends StatelessWidget {
   }
 }
 
+// YouTube API Service
 class YouTubeService {
-  static const String apiKey = 'AIzaSyABnUHeSMZtrTAJCgWhpn-woVWehjIBolA';
-
   static Future<List<VideoItem>> fetchLatestVideos(String channelId) async {
     final url = Uri.parse(
-      'https://www.googleapis.com/youtube/v3/search?key=$apiKey&channelId=$channelId&part=snippet,id&order=date&maxResults=5',
+      'https://www.googleapis.com/youtube/v3/search?key=${AppConstants.youtubeApiKey}&channelId=$channelId&part=snippet,id&order=date&maxResults=5',
     );
 
     final response = await http.get(url);
@@ -334,7 +272,7 @@ class BlogItem {
 
 class BlogService {
   static Future<List<BlogItem>> fetchLatestPosts() async {
-    // Simulating no data; when ready replace with real fetching logic.
+    // Placeholder, implement WordPress blog fetching logic here
     return Future.delayed(const Duration(seconds: 1), () => []);
   }
 }

--- a/lib/pages/explore_page.dart
+++ b/lib/pages/explore_page.dart
@@ -1,5 +1,3 @@
-// lib/pages/explore_page.dart
-
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
@@ -10,22 +8,26 @@ class ExplorePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _buildTopBar(),
-        Expanded(
-          child: SingleChildScrollView(
-            child: Column(
-              children: [
-                _buildBlogSection(),
-                _buildYouTubeSection(),
-                _buildLibrarySection(),
-              ],
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildTopBar(),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    _buildBlogSection(),
+                    _buildYouTubeSection(),
+                    _buildLibrarySection(),
+                  ],
+                ),
+              ),
             ),
-          ),
+          ],
         ),
-      ],
+      ),
     );
   }
 
@@ -228,7 +230,6 @@ class ExplorePage extends StatelessWidget {
   }
 }
 
-// YouTube API Service
 class YouTubeService {
   static Future<List<VideoItem>> fetchLatestVideos(String channelId) async {
     final url = Uri.parse(
@@ -272,7 +273,6 @@ class BlogItem {
 
 class BlogService {
   static Future<List<BlogItem>> fetchLatestPosts() async {
-    // Placeholder, implement WordPress blog fetching logic here
     return Future.delayed(const Duration(seconds: 1), () => []);
   }
 }

--- a/lib/utility/constants.dart
+++ b/lib/utility/constants.dart
@@ -1,0 +1,14 @@
+// lib/constants.dart
+
+class AppConstants {
+  // YouTube API
+  static const String youtubeApiKey = 'AIzaSyABnUHeSMZtrTAJCgWhpn-woVWehjIBolA';
+
+  // YouTube Channel IDs
+  static const String drKerYouTubeChannelId = 'UCkcmd1DLH_6kpc9yoBqO9wg';
+  static const String drKerLibraryChannelId = 'UCHwMNHKk2uzTEENHnRrs9Ew';
+
+  // WordPress (Blog) API
+  static const String wordpressApiBaseUrl = 'https://drkerministry.com/wp-json/wp/v2/';
+  static const String wordpressApiKey = 'YOUR_WORDPRESS_API_KEY'; // Optional, if using authentication
+}


### PR DESCRIPTION
- Extracted bottom navigation bar from ExplorePage and implemented it in main.dart as part of a new HomePage widget.
- ExplorePage now focuses solely on displaying blog, YouTube, and library content.
- This structure improves scalability and keeps ExplorePage clean and modular.
- Ready to merge into main for unified navigation across the app.