### PR TITLE
Fix HTML entities in blog and YouTube search titles 

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -104,6 +104,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.5+1"
+  html_unescape:
+    dependency: "direct main"
+    description:
+      name: html_unescape
+      sha256: "15362d7a18f19d7b742ef8dcb811f5fd2a2df98db9f80ea393c075189e0b61e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   url_launcher: ^6.3.1
+  html_unescape: ^2.0.0
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Decoded HTML entities such as `&nbsp;`, `&quot;`, etc. using `html_unescape`
- Cleaned up final model assignments
- Removed fallback thumbnail from blog items
- Added `html_unescape` to pubspec.yaml