### PR TITLE
Enhance video interaction with animated clickable video cards 

### DIFF
--- a/lib/pages/explore/widgets/library_section.dart
+++ b/lib/pages/explore/widgets/library_section.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:drkerapp/models/video_item.dart';
 import 'package:drkerapp/services/youtube_service.dart';
 import 'package:drkerapp/utility/constants.dart';
-import 'package:drkerapp/widgets/video_card.dart';
 import 'package:drkerapp/widgets/horizontal_card_list.dart';
+import 'package:drkerapp/widgets/animated_video_card.dart';
 
 class LibrarySection extends StatelessWidget {
   const LibrarySection({super.key});
@@ -25,7 +25,7 @@ class LibrarySection extends StatelessWidget {
           );
         } else {
           final cards = snapshot.data!
-              .map((video) => VideoCard(title: video.title, imageUrl: video.thumbnailUrl))
+              .map((video) => AnimatedVideoCard(video: video))
               .toList();
           return HorizontalCardList(title: 'DrKerLibrary', cards: cards);
         }

--- a/lib/pages/explore/widgets/youtube_section.dart
+++ b/lib/pages/explore/widgets/youtube_section.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:drkerapp/models/video_item.dart';
 import 'package:drkerapp/services/youtube_service.dart';
 import 'package:drkerapp/utility/constants.dart';
-import 'package:drkerapp/widgets/video_card.dart';
 import 'package:drkerapp/widgets/horizontal_card_list.dart';
+import 'package:drkerapp/widgets/animated_video_card.dart';
 
 class YouTubeSection extends StatelessWidget {
   const YouTubeSection({super.key});
@@ -25,7 +25,7 @@ class YouTubeSection extends StatelessWidget {
           );
         } else {
           final cards = snapshot.data!
-              .map((video) => VideoCard(title: video.title, imageUrl: video.thumbnailUrl))
+              .map((video) => AnimatedVideoCard(video: video))
               .toList();
           return HorizontalCardList(title: 'DrKerYouTube', cards: cards);
         }

--- a/lib/widgets/animated_video_card.dart
+++ b/lib/widgets/animated_video_card.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:drkerapp/models/video_item.dart';
+import 'video_card.dart';
+
+class AnimatedVideoCard extends StatefulWidget {
+  final VideoItem video;
+
+  const AnimatedVideoCard({super.key, required this.video});
+
+  @override
+  State<AnimatedVideoCard> createState() => _AnimatedVideoCardState();
+}
+
+class _AnimatedVideoCardState extends State<AnimatedVideoCard> {
+  double _scale = 1.0;
+
+  void _launchVideo() async {
+    final uri = Uri.parse('https://www.youtube.com/watch?v=${widget.video.videoId}');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.platformDefault);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('ไม่สามารถเปิดวิดีโอได้')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _scale = 0.95),
+      onTapUp: (_) => setState(() => _scale = 1.0),
+      onTapCancel: () => setState(() => _scale = 1.0),
+      onTap: _launchVideo,
+      child: AnimatedScale(
+        scale: _scale,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.easeInOut,
+        child: VideoCard(
+          title: widget.video.title,
+          imageUrl: widget.video.thumbnailUrl,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR improves user experience in the YouTubeSection and LibrarySection by introducing an AnimatedVideoCard widget. Key changes include:

Created a reusable AnimatedVideoCard widget that provides a scaling animation on tap.

Integrated this widget into both YouTubeSection and LibrarySection.

Replaced static VideoCard taps with animated gesture-based navigation to YouTube videos.

Modularized the code for easier maintenance and consistency.

Why?

Enhances visual feedback when tapping video thumbnails.

Ensures consistent navigation behavior across the app.

Promotes reusability through component abstraction.

